### PR TITLE
Add timeout option in requests

### DIFF
--- a/flickrapi/auth.py
+++ b/flickrapi/auth.py
@@ -234,7 +234,7 @@ class OAuthFlickrInterface(object):
         
         return os.path.expanduser('~/.flickrapi/cache')
 
-    def do_request(self, url, params=None):
+    def do_request(self, url, params=None, timeout=None):
         """Performs the HTTP request, signed with OAuth.
         
         @return: the response content
@@ -243,7 +243,8 @@ class OAuthFlickrInterface(object):
         req = requests.post(url,
                             params=params,
                             auth=self.oauth,
-                            headers={'Connection': 'close'})
+                            headers={'Connection': 'close'},
+                            timeout=timeout)
         
         # check the response headers / status code.
         if req.status_code != 200:

--- a/flickrapi/core.py
+++ b/flickrapi/core.py
@@ -137,8 +137,8 @@ class FlickrAPI(object):
     REPLACE_URL = 'https://up.flickr.com/services/replace/'
     
     def __init__(self, api_key, secret, username=None,
-            token=None, format='etree', store_token=True,
-            cache=False):
+                 token=None, format='etree', store_token=True,
+                 cache=False, timeout=None):
         """Construct a new FlickrAPI instance for a given API key
         and secret.
         
@@ -174,6 +174,9 @@ class FlickrAPI(object):
 
             >>> f = FlickrAPI(u'123', u'123')
             >>> f.cache = SimpleCache(timeout=5, max_entries=100)
+
+        timeout
+            Timeout to use for the HTTP requests. Default is None, i.e. no timeout.
         """
 
 
@@ -204,6 +207,8 @@ class FlickrAPI(object):
             self.cache = SimpleCache()
         else:
             self.cache = None
+
+        self.timeout = timeout if timeout > 0 else None
 
     def __repr__(self):
         """Returns a string representation of this object."""
@@ -359,7 +364,8 @@ class FlickrAPI(object):
         if self.cache and self.cache.get(kwargs):
             return self.cache.get(kwargs)
 
-        reply = self.flickr_oauth.do_request(self.REST_URL, kwargs)
+        reply = self.flickr_oauth.do_request(self.REST_URL, kwargs,
+                                             self.timeout)
 
         # Store in cache, if we have one
         if self.cache is not None:


### PR DESCRIPTION
I added a timeout attribute to FlickrAPI objects in order to partially solve issue #27. While it does not allow to give a timeout on a per request basis it can do it globally without affecting non-Flickr requests.