### PR TITLE
Update README to note py.test instead of nose

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ For development, install extra dependencies using:
     
     pip install -r requirements.txt 
 
-then run `nosetest` in the top-level directory.
+then run `py.test` in the top-level directory.
 
 Generating the documentation
 ----------------------------


### PR DESCRIPTION
Instructions in tox.ini and requirements.txt have been updated to use py.test, except README. Let's keep them in sync :)