### PR TITLE
Post params as payload, not uri

### DIFF
--- a/flickrapi/auth.py
+++ b/flickrapi/auth.py
@@ -246,7 +246,7 @@ class OAuthFlickrInterface(object):
         """
 
         req = requests.post(url,
-                            params=params,
+                            data=params,
                             auth=self.oauth,
                             headers={'Connection': 'close'})
 

--- a/tests/test_flickrapi.py
+++ b/tests/test_flickrapi.py
@@ -178,7 +178,7 @@ class FlickrApiTest(SuperTest):
         # make sure this test is made without a valid token in the cache        
         del self.f.token_cache.token
 
-        self.expect(body={'method': 'flickr.photos.getInfo', 'photo_id': '7955646798'},
+        self.expect({'method': 'flickr.photos.getInfo', 'photo_id': '7955646798'},
                     PHOTO_XML)
 
         self.f.photos.getInfo(photo_id='7955646798')
@@ -187,7 +187,7 @@ class FlickrApiTest(SuperTest):
     def test_simple_search(self):
         '''Test simple Flickr search'''
 
-        self.expect(body={'method': 'flickr.photos.search', 'tags': 'kitten'},
+        self.expect({'method': 'flickr.photos.search', 'tags': 'kitten'},
                     KITTEN_SEARCH_XML)
         
         # We expect to be able to find kittens

--- a/tests/test_flickrapi.py
+++ b/tests/test_flickrapi.py
@@ -178,7 +178,7 @@ class FlickrApiTest(SuperTest):
         # make sure this test is made without a valid token in the cache        
         del self.f.token_cache.token
 
-        self.expect({'method': 'flickr.photos.getInfo', 'photo_id': '7955646798'},
+        self.expect(body={'method': 'flickr.photos.getInfo', 'photo_id': '7955646798'},
                     PHOTO_XML)
 
         self.f.photos.getInfo(photo_id='7955646798')
@@ -187,7 +187,7 @@ class FlickrApiTest(SuperTest):
     def test_simple_search(self):
         '''Test simple Flickr search'''
 
-        self.expect({'method': 'flickr.photos.search', 'tags': 'kitten'},
+        self.expect(body={'method': 'flickr.photos.search', 'tags': 'kitten'},
                     KITTEN_SEARCH_XML)
         
         # We expect to be able to find kittens


### PR DESCRIPTION
Post params as payload, not uri
Because when you try to reorder big sets, you'll get "414 Request-URI Too Large" if you put all ids in uri ..

Not tested yet, but should be ok.