### PR TITLE
Commit database after creating oauth_tokens table. Fixes #75

### DIFF
--- a/flickrapi/tokencache.py
+++ b/flickrapi/tokencache.py
@@ -165,6 +165,8 @@ class OAuthTokenCache(object):
                         user_nsid varchar(64) not null,
                         PRIMARY KEY(api_key, lookup_key))''')
 
+        db.commit()
+
     @property
     def token(self):
         """Return the cached token for this API key, or None if not found."""

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35,pypy
+envlist = py27,py33,py34,py35,py36,pypy
 
 [pytest]
 addopts = -v --cov flickrapi --cov-report term-missing


### PR DESCRIPTION
This change seems to be required in Python 3.6.0. It works correctly without the db.commit() in 3.5.2 and earlier. Without the commit the first table, oauth_cache_db_version, gets created, but oauth_tokens does not.

I ran the unit tests on 3.5.2 after making the change and all passed. I couldn't run them on 3.6.0 because pytest isn't supported there yet. I did make the change and test manually in 3.6.0.  All tests were on Windows 10.