### PR TITLE
Fix parameter naming conflict

### DIFF
--- a/flickrapi/core.py
+++ b/flickrapi/core.py
@@ -309,7 +309,7 @@ class FlickrAPI(object):
 
         return CallBuilder(self, method_name='flickr.' + method_name)
 
-    def do_flickr_call(self, method_label, timeout=None, **kwargs):
+    def do_flickr_call(self, _method_name, timeout=None, **kwargs):
         """Handle all the regular Flickr API calls.
 
         Example::
@@ -323,7 +323,7 @@ class FlickrAPI(object):
         params = kwargs.copy()
 
         # Set some defaults
-        defaults = {'method': method_label,
+        defaults = {'method': _method_name,
                     'format': self.default_format}
         if 'jsoncallback' not in kwargs:
             defaults['nojsoncallback'] = 1

--- a/flickrapi/core.py
+++ b/flickrapi/core.py
@@ -309,7 +309,7 @@ class FlickrAPI(object):
 
         return CallBuilder(self, method_name='flickr.' + method_name)
 
-    def do_flickr_call(self, method_name, timeout=None, **kwargs):
+    def do_flickr_call(self, method_label, timeout=None, **kwargs):
         """Handle all the regular Flickr API calls.
 
         Example::
@@ -323,7 +323,7 @@ class FlickrAPI(object):
         params = kwargs.copy()
 
         # Set some defaults
-        defaults = {'method': method_name,
+        defaults = {'method': method_label,
                     'format': self.default_format}
         if 'jsoncallback' not in kwargs:
             defaults['nojsoncallback'] = 1


### PR DESCRIPTION
Fixes #90.

`method_name` parameter from `do_flickr_call()` method signature
clashes with `method_name` parameter required by the Flickr API method `flickr.reflection.getMethodInfo`.