### PR TITLE
Drop support for EOL Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ matrix:
   include:
   - python: '2.7'
     env: TOXENV=py27
-  - python: '3.3'
-    env: TOXENV=py33
   - python: '3.4'
     env: TOXENV=py34
   - python: '3.5'

--- a/README.md
+++ b/README.md
@@ -18,24 +18,24 @@ To install the latest version from PyPi:
     pip install flickrapi
 
 For development, install extra dependencies using:
-    
-    pip install -r requirements.txt 
+
+    pip install -r requirements.txt
 
 then run `py.test` in the top-level directory.
 
 Supported Python versions
 -------------------------
 
-The minimum Python versions that are supported are 2.7 and 3.3.
+The minimum Python versions that are supported are 2.7 and 3.4.
 
 [Python 2.7 will be discontinued in 2020](http://www.i-programmer.info/news/216-python/7179-python-27-to-be-maintained-until-2020.html),
 which also marks the end of the support for Python 2.x for this
 library. We might discontinue supporting Python 2.x earlier than that,
 but only if there is a very compelling reason to do so.
 
-As of September 2017, [Python 3.3 will stop receiving security
+As of September 2017, [Python 3.3 stopped receiving security
 updates](https://www.python.org/dev/peps/pep-0398/#lifespan),
-at which time this library will also stop supporting it.
+at which time this library also stopped supporting it.
 
 
 Generating the documentation

--- a/doc/1-intro.rst
+++ b/doc/1-intro.rst
@@ -61,7 +61,7 @@ Requirements and compatibility
 ----------------------------------------------------------------------
 
 The Python Flickr API uses two external libraries, Requests_ and Six_,
-and is compatible with Python 2.7 and 3.3+.
+and is compatible with Python 2.7 and 3.4+.
 
 Rendering the documentation requires `Sphinx <http://sphinx-doc.org/>`_.
 

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,8 @@ import sys
 
 (major, minor) = sys.version_info[:2]
 
-if (major, minor) < (2, 7) or (major == 3 and minor < 3):
-    raise SystemExit("Sorry, Python 2.7, or 3.3 or newer required")
+if (major, minor) < (2, 7) or (major == 3 and minor < 4):
+    raise SystemExit("Sorry, Python 2.7, or 3.4 or newer required")
 
 from setuptools import setup
 
@@ -44,12 +44,14 @@ data = {
         'License :: OSI Approved :: Python License (CNRI Python License)',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Multimedia :: Graphics',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35,py36,pypy
+envlist = py27,py34,py35,py36,pypy
 
 [pytest]
 addopts = -v --cov flickrapi --cov-report term-missing


### PR DESCRIPTION
The [README](https://github.com/sybrenstuvel/flickrapi#supported-python-versions) says:

> As of September 2017, [Python 3.3 will stop receiving security updates](https://www.python.org/dev/peps/pep-0398/#lifespan), at which time this library will also stop supporting it.

So here we go!