### PR TITLE
Updated urls in documentation, docstrings, and shorturl module to use https.

### DIFF
--- a/UPGRADING.txt
+++ b/UPGRADING.txt
@@ -7,7 +7,7 @@ From any 1.x release to 2.0:
 For this release the main goal was to quickly transition from the obsolete
 authentication method to OAuth. As a result, some features of the 1.x version
 have been dropped. If you want any of those features back, let me know at:
-https://bitbucket.org/sybren/flickrapi/issues?status=new&status=open
+https://github.com/sybrenstuvel/flickrapi/issues
 
 
 Authentication has been re-written to use OAuth. See the documentation

--- a/doc/1-intro.rst
+++ b/doc/1-intro.rst
@@ -9,9 +9,9 @@ than this document could be. Since the Python Flickr API uses dynamic
 methods and introspection, you can call new Flickr methods as soon as
 they become available.
 
-.. _`Flickr API documentation`: http://www.flickr.com/services/api/
-.. _`Flickr`: http://www.flickr.com/
-.. _`Python Flickr API interface`: http://stuvel.eu/flickrapi
+.. _`Flickr API documentation`: https://www.flickr.com/services/api/
+.. _`Flickr`: https://www.flickr.com/
+.. _`Python Flickr API interface`: https://stuvel.eu/flickrapi
 
 
 Concepts
@@ -63,10 +63,10 @@ Requirements and compatibility
 The Python Flickr API uses two external libraries, Requests_ and Six_,
 and is compatible with Python 2.7 and 3.4+.
 
-Rendering the documentation requires `Sphinx <http://sphinx-doc.org/>`_.
+Rendering the documentation requires `Sphinx <http://www.sphinx-doc.org/>`_.
 
 .. _Requests: http://docs.python-requests.org/
-.. _Six: http://packages.python.org/six/
+.. _Six: https://pythonhosted.org/six/
 
 
 Upgrading
@@ -80,7 +80,7 @@ From 1.x to 2.0
 For this release the main goal was to quickly transition from the obsolete
 authentication method to OAuth. As a result, some features of the 1.x version
 have been dropped. If you want any of those features back, let me know at:
-https://bitbucket.org/sybren/flickrapi/issues?status=new&status=open
+https://github.com/sybrenstuvel/flickrapi/issues
 
 
 Authentication has been re-written to use OAuth. See the documentation

--- a/doc/2-calling.rst
+++ b/doc/2-calling.rst
@@ -16,7 +16,7 @@ some examples::
     photos = flickr.photos.search(user_id='73509078@N00', per_page='10')
     sets = flickr.photosets.getList(user_id='73509078@N00')
 
-.. _`Flickr Services`: http://www.flickr.com/services/api/keys/apply/
+.. _`Flickr Services`: https://www.flickr.com/services/api/keys/apply/
 
 The API key and secret MUST be Unicode strings. All parameters you pass
 to Flickr MUST be passed as keyword arguments.

--- a/doc/3-auth.rst
+++ b/doc/3-auth.rst
@@ -3,7 +3,7 @@ Authentication and Authorization
 ======================================================================
 
 For authentication and authorization Flickr uses
-`OAuth 1.0a <http://oauth.net/core/1.0a/>`_. This ensures that in one
+`OAuth 1.0a <https://oauth.net/core/1.0a/>`_. This ensures that in one
 flow, the user is authenticated via the Flickr website, and the application
 is authorized by the user to act in its name.
 
@@ -39,7 +39,7 @@ Here is a simple example that does all the above in one simple call to
     flickr.authenticate_via_browser(perms='read')
 
 The ``api_key`` and ``api_secret`` can be obtained from
-http://www.flickr.com/services/api/keys/. Every application should use
+https://www.flickr.com/services/api/keys/. Every application should use
 its own key and secret.
 
 The call to ``flickr.authenticate_via_browser(...)`` does a lot of
@@ -56,7 +56,7 @@ code. The code is passed then to the application. When this code has
 been received, the token is stored in the token cache and the
 authentication process is complete.
 
-.. _`User Authentication`: http://www.flickr.com/services/api/auth.oauth.html
+.. _`User Authentication`: https://www.flickr.com/services/api/auth.oauth.html
 
 Non-web applications
 --------------------------------------------------
@@ -258,7 +258,7 @@ Here is a simple example in `Django <https://www.djangoproject.com/>`_::
 
 Every view that calls an authenticated Flickr method should be
 decorated with ``@require_flickr_auth``. For more information on
-function decorators, see `PEP 318 <http://www.python.org/dev/peps/pep-0318/>`_.
+function decorators, see `PEP 318 <https://www.python.org/dev/peps/pep-0318/>`_.
 
 The ``callback`` view should be called when the user is sent to the
 callback URL as defined in your Flickr API key. The key and secret

--- a/doc/7-util.rst
+++ b/doc/7-util.rst
@@ -22,7 +22,7 @@ The function uses the Flickr API call flickr.photosets.getPhotos_ and
 accepts the same parameters. The resulting "photo" objects are
 ElementTree objects for the ``<photo .../>`` XML elements.
 
-.. _flickr.photosets.getPhotos: http://www.flickr.com/services/api/flickr.photosets.getPhotos.html
+.. _flickr.photosets.getPhotos: https://www.flickr.com/services/api/flickr.photosets.getPhotos.html
 
 
 Walking through a search result
@@ -42,7 +42,7 @@ The function uses the Flickr API call flickr.photos.search_ and
 accepts the same parameters. The resulting "photo" objects are
 ElementTree objects for the ``<photo .../>`` XML elements.
 
-.. _flickr.photos.search: http://www.flickr.com/services/api/flickr.photos.search.html
+.. _flickr.photos.search: https://www.flickr.com/services/api/flickr.photos.search.html
 
 
 Influencing the number of calls to Flickr

--- a/doc/8-shorturl.rst
+++ b/doc/8-shorturl.rst
@@ -3,7 +3,7 @@ Short Flickr URLs
 ======================================================================
 
 Flickr supports linking to a photo page using a short url such as
-http://flic.kr/p/6BTTT6. The ``flickrapi.shorturl`` module contains
+https://flic.kr/p/6BTTT6. The ``flickrapi.shorturl`` module contains
 functionality for working with those short URLs.
 
 ``flickrapi.shorturl.encode(photo ID)``:

--- a/doc/9-links.rst
+++ b/doc/9-links.rst
@@ -6,6 +6,6 @@ Links
 - `Flickr`_
 - `Flickr API documentation`_
 
-.. _`Python Flickr API interface`: http://stuvel.eu/flickrapi
-.. _`Flickr`: http://www.flickr.com/
-.. _`Flickr API documentation`: http://www.flickr.com/services/api/
+.. _`Python Flickr API interface`: https://stuvel.eu/flickrapi
+.. _`Flickr`: https://www.flickr.com/
+.. _`Flickr API documentation`: https://www.flickr.com/services/api/

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -7,8 +7,8 @@ some way or another. The possibilities are limitless. This document
 describes how to use the Flickr API in your Python programs using the
 `Python Flickr API interface`_.
 
-.. _`Flickr`: http://www.flickr.com/
-.. _`Python Flickr API interface`: http://stuvel.eu/flickrapi
+.. _`Flickr`: https://www.flickr.com/
+.. _`Python Flickr API interface`: https://stuvel.eu/flickrapi
 
 
 Contents:

--- a/flickrapi/__init__.py
+++ b/flickrapi/__init__.py
@@ -8,15 +8,15 @@ class.
 
 See `the FlickrAPI homepage`_ for more info.
 
-.. _`the FlickrAPI homepage`: http://stuvel.eu/projects/flickrapi
+.. _`the FlickrAPI homepage`: https://stuvel.eu/flickrapi
 """
 from __future__ import unicode_literals
 
 # Copyright (c) 2007-2018 by the respective coders, see
-# http://stuvel.eu/flickrapi
+# https://stuvel.eu/flickrapi
 #
 # This code is subject to the Python licence, as can be read on
-# http://www.python.org/download/releases/2.5.2/license/
+# https://www.python.org/download/releases/2.5.2/license/
 #
 # For those without an internet connection, here is a summary. When this
 # summary clashes with the Python licence, the latter will be applied.

--- a/flickrapi/cache.py
+++ b/flickrapi/cache.py
@@ -6,7 +6,7 @@ Designed to have the same interface as the `Django low-level cache API`_.
 Heavily inspired (read: mostly copied-and-pasted) from the Django framework -
 thanks to those guys for designing a simple and effective cache!
 
-.. _`Django low-level cache API`: http://www.djangoproject.com/documentation/cache/#the-low-level-cache-api
+.. _`Django low-level cache API`: https://docs.djangoproject.com/en/dev/topics/cache/#the-low-level-cache-api
 """
 
 import threading

--- a/flickrapi/core.py
+++ b/flickrapi/core.py
@@ -715,7 +715,7 @@ class FlickrAPI(object):
         returned eventually.
 
         .. _flickr.contacts.getList:
-            http://www.flickr.com/services/api/flickr.contacts.getList.html
+            https://www.flickr.com/services/api/flickr.contacts.getList.html
 
         Uses the ElementTree format, incompatible with other formats.
         """
@@ -739,7 +739,7 @@ class FlickrAPI(object):
         returned eventually.
 
         .. _flickr.photosets.getList:
-            http://www.flickr.com/services/api/flickr.photosets.getList.html
+            https://www.flickr.com/services/api/flickr.photosets.getList.html
 
         Uses the ElementTree format, incompatible with other formats.
         """
@@ -765,7 +765,7 @@ class FlickrAPI(object):
         returned eventually.
 
         .. _flickr.photosets.getPhotos:
-            http://www.flickr.com/services/api/flickr.photosets.getPhotos.html
+            https://www.flickr.com/services/api/flickr.photosets.getPhotos.html
 
         Uses the ElementTree format, incompatible with other formats.
         """
@@ -791,7 +791,7 @@ class FlickrAPI(object):
         returned eventually.
 
         .. _flickr.people.getPhotos:
-            http://www.flickr.com/services/api/flickr.people.getPhotos.html
+            https://www.flickr.com/services/api/flickr.people.getPhotos.html
 
         Uses the ElementTree format, incompatible with other formats.
         """
@@ -818,7 +818,7 @@ class FlickrAPI(object):
         returned eventually.
 
         .. _flickr.photos.recentlyUpdated:
-            http://www.flickr.com/services/api/flickr.photos.recentlyUpdated.html
+            https://www.flickr.com/services/api/flickr.photos.recentlyUpdated.html
 
         Uses the ElementTree format, incompatible with other formats.
         """
@@ -836,7 +836,7 @@ class FlickrAPI(object):
         eventually.
 
         .. _flickr.photos.search:
-            http://www.flickr.com/services/api/flickr.photos.search.html
+            https://www.flickr.com/services/api/flickr.photos.search.html
 
         Also see `walk_set`.
         """

--- a/flickrapi/html.py
+++ b/flickrapi/html.py
@@ -72,7 +72,7 @@ auth_okay_html = """<!DOCTYPE html>
         You can now <strong>close this browser window</strong>, and return to the application.</p>
         
         <p class='note'>Powered by
-            <a href='http://stuvel.eu/flickrapi'>Python FlickrAPI</a>, by Sybren A. Stüvel.</p>
+            <a href='https://stuvel.eu/flickrapi'>Python FlickrAPI</a>, by Sybren A. Stüvel.</p>
     </article>
 </section>
 </body>

--- a/flickrapi/shorturl.py
+++ b/flickrapi/shorturl.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 
-"""Helper functions for the short http://fli.kr/p/... URL notation.
+"""Helper functions for the short https://fli.kr/p/... URL notation.
 
 Photo IDs can be converted to and from Base58 short IDs, and a short
 URL can be generated from a photo ID.
 
 The implementation of the encoding and decoding functions is based on
 the posts by stevefaeembra and Kohichi on
-http://www.flickr.com/groups/api/discuss/72157616713786392/
+https://www.flickr.com/groups/api/discuss/72157616713786392/
 
 """
 
@@ -17,7 +17,7 @@ __all__ = ['encode', 'decode', 'url', 'SHORT_URL']
 
 ALPHABET = u'123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ'
 ALPHALEN = len(ALPHABET)
-SHORT_URL = u'http://flic.kr/p/%s'
+SHORT_URL = u'https://flic.kr/p/%s'
 
 
 def encode(photo_id):
@@ -67,9 +67,9 @@ def url(photo_id):
     """url(photo id) -> short url
 
     >>> url(u'4325695128')
-    'http://flic.kr/p/7Afjsu'
+    'https://flic.kr/p/7Afjsu'
     >>> url(u'2811466321')
-    'http://flic.kr/p/5hruZg'
+    'https://flic.kr/p/5hruZg'
     """
 
     short_id = encode(photo_id)

--- a/tests/test_shorturl.py
+++ b/tests/test_shorturl.py
@@ -24,6 +24,6 @@ class ShortUrlTest(unittest.TestCase):
         '''Test photo ID to short URL conversion.'''
 
         self.assertEqual(shorturl.url(u'4325695128'),
-                u'http://flic.kr/p/7Afjsu')
+                u'https://flic.kr/p/7Afjsu')
         self.assertEqual(shorturl.url(u'2811466321'),
-                u'http://flic.kr/p/5hruZg')
+                u'https://flic.kr/p/5hruZg')


### PR DESCRIPTION
Went through the documentation and docstrings and updated urls to use https instead of http (where available) and also updated url locations where changed.

Updated the `flickrapi.shorturl` module and its tests to use https for the short url produced.

There are still some urls in the `oauth_test_*.py` files that are http, but maybe should be https now, I did not verify or update them.