### PR TITLE
In Python 3.7 the async keyword cannot be used to add param async=1 t…

### DIFF
--- a/flickrapi/auth.py
+++ b/flickrapi/auth.py
@@ -277,6 +277,11 @@ class OAuthFlickrInterface(object):
         if 'title' not in params:
             params['title'] = os.path.basename(filename).encode('utf8')
 
+        if 'asynchronous' in params:
+            if int(params['asynchronous']) == 1:
+                params['async'] = '1'
+            params.pop('asynchronous')
+
         # work-around for Flickr expecting 'photo' to be excluded
         # from the oauth signature:
         #   1. create a dummy request without 'photo'

--- a/flickrapi/core.py
+++ b/flickrapi/core.py
@@ -459,6 +459,8 @@ class FlickrAPI(object):
         hidden
             Set to "1" to keep the photo in global search results, "2"
             to hide from public searches.
+        asynchronous
+            Set to "1" to do async upload
         format
             The response format. You can only choose between the
             parsed responses or 'rest' for plain REST.
@@ -504,6 +506,8 @@ class FlickrAPI(object):
             an optional file-like object from which the data can be read
         photo_id
             the ID of the photo to replace
+        asynchronous
+            Set to "1" to do async upload
         format
             The response format. You can only choose between the
             parsed responses or 'rest' for plain REST. Defaults to the


### PR DESCRIPTION
…o flickr API

In Python 3.7 the async keyword cannot be used to add param async=1 to flickr API.
So I add the asychronous param in the upload and replace function.

Thanks.