### PR TITLE
Add support for Python 3.7 and fix Flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: python
 cache: pip
 
@@ -17,6 +16,9 @@ matrix:
     env: TOXENV=py35
   - python: '3.6'
     env: TOXENV=py36
+  - python: '3.7'
+    env: TOXENV=py37
+    dist: xenial
   - python: 'pypy'
     env: TOXENV=pypy
   - python: 3.5

--- a/flickrapi/tokencache.py
+++ b/flickrapi/tokencache.py
@@ -310,8 +310,8 @@ class LockingTokenCache(TokenCache):
 
                 if time.time() - start_time >= timeout:
                     # Timeout has passed, bail out
-                    raise LockingError('Unable to acquire lock ' +
-                                       '%s, aborting' % lock)
+                    raise LockingError('Unable to acquire lock '
+                                        + '%s, aborting' % lock)
 
                 # Wait for a bit, then try again
                 LOG.debug('Unable to acquire lock, waiting')
@@ -337,8 +337,8 @@ class LockingTokenCache(TokenCache):
         # If the PID file isn't ours, abort.
         lockpid = self.get_lock_pid()
         if lockpid and lockpid != os.getpid():
-            raise LockingError(('Lock %s is NOT ours, but belongs ' +
-                                'to PID %i, unable to release.') % (lock, lockpid))
+            raise LockingError(('Lock %s is NOT ours, but belongs '
+                                 + 'to PID %i, unable to release.') % (lock, lockpid))
 
         LOG.debug('Releasing lock %s' % lock)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 universal = 1
 
 [flake8]
-ignore = E121, E122, E127, E128, E241, E265, E305, E402, E501, E731, F403, F405, W601
+ignore = E121, E122, E127, E128, E241, E265, E305, E402, E501, E731, F403, F405, W503, W601
 exclude =
     .AppleDouble,
     .ropeproject,

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ data = {
     ],
     'setup_requires': pytest_runner,
     'tests_require': test_deps,
+    'python_requires': '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     'install_requires': [
         'six>=1.5.2',
         'requests>=2.2.1',

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ data = {
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Multimedia :: Graphics',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36},pypy,qa,doc
+envlist = py{27,34,35,36,37},pypy,qa,doc
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Add support for Python 3.7, it needs Xenial on Travis CI.

(Also `sudo:` is no longer required: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)

---

A new release of Flake8 has caused the [QA build job](https://travis-ci.org/hugovk/flickrapi/builds/490916449) to fail with:

```
W504 line break after binary operator
```

Fixing these cause: 
```
W503 line break before binary operator
```

W503 and W504 are not compatible with each other, so one needs ignoring. W503 is not compatible with PEP 8, so ignore it. (If you prefer it the other way, let's ignore the other one.)
