### PR TITLE
Fix deprecation warnings

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -26,14 +26,14 @@ class TestCache(unittest.TestCase):
         key = 'abc'
         cache.set(key, 'def')
         time.sleep(1.1)
-        self.assertFalse(key in cache)
+        self.assertNotIn(key, cache)
 
     def test_delete(self):
         cache = flickrapi.SimpleCache()
         key = 'abc'
         cache.set(key, 'def')
         cache.delete(key)
-        self.assertFalse(key in cache)
+        self.assertNotIn(key, cache)
 
     def test_max_entries(self):
         max_entries = 90

--- a/tests/test_flickrapi.py
+++ b/tests/test_flickrapi.py
@@ -194,8 +194,8 @@ class FlickrApiTest(MockedTest):
         '''Class name and API key should be in repr output'''
 
         r = repr(self.f)
-        self.assertTrue('FlickrAPI' in r)
-        self.assertTrue(key in r)
+        self.assertIn('FlickrAPI', r)
+        self.assertIn(key, r)
 
     def test_defaults(self):
         '''Tests _supply_defaults.'''
@@ -224,7 +224,7 @@ class FlickrApiTest(MockedTest):
         # We expect to be able to find kittens
         result = self.f.photos.search(tags='kitten')
         total = int(result.find('photos').attrib['total'])
-        self.assertTrue(total > 0)
+        self.assertGreater(total, 0)
 
     def test_token_constructor(self):
         '''Test passing a token to the constructor'''
@@ -378,7 +378,7 @@ class FormatsTest(SuperTest):
 
         # Try to parse it
         rst = flickrapi.XMLNode.parse(xml, False)
-        self.assertTrue(int(rst.photos[0]['total']) > 0)
+        self.assertGreater(int(rst.photos[0]['total']), 0)
 
     def test_json_format(self):
         '''Test json format (no callback)'''

--- a/tests/test_tokencache.py
+++ b/tests/test_tokencache.py
@@ -11,7 +11,7 @@ class SimpleTokenCacheTest(unittest.TestCase):
         self.assertIsNone(self.tc.token)
 
         self.tc.token = 'nümbér'
-        self.assertEquals(self.tc.token, 'nümbér')
+        self.assertEqual(self.tc.token, 'nümbér')
 
         del self.tc.token
         self.assertIsNone(self.tc.token)
@@ -41,13 +41,13 @@ class TokenCacheTest(unittest.TestCase):
 
         # Check setting token, both in memory and on disk.
         self.tc.token = u'nümbér'
-        self.assertEquals(self.tc.token, u'nümbér')
+        self.assertEqual(self.tc.token, u'nümbér')
         on_disk = open(self.tc.get_cached_token_filename(), 'rb').read()
-        self.assertEquals(on_disk.decode('utf8'), u'nümbér')
+        self.assertEqual(on_disk.decode('utf8'), u'nümbér')
 
         # Erase from in-RAM cache and try again, to read from disk.
         self.tc.memory.clear()
-        self.assertEquals(self.tc.token, u'nümbér')
+        self.assertEqual(self.tc.token, u'nümbér')
 
         del self.tc.token
         self.assertIsNone(self.tc.token)
@@ -96,16 +96,16 @@ class OAuthTokenCache(unittest.TestCase):
 
         # Check setting token
         self.tc.token = self.token
-        self.assertEquals(self.tc.token.token, u'nümbér')
+        self.assertEqual(self.tc.token.token, u'nümbér')
 
         # Erase from in-RAM cache and try again, to read from disk.
         self.tc.RAM_CACHE.clear()
-        self.assertEquals(self.tc.token.token, u'nümbér')
-        self.assertEquals(self.tc.token.token_secret, u'səcret-tøken')
-        self.assertEquals(self.tc.token.access_level, u'read')
-        self.assertEquals(self.tc.token.fullname, u'My Full Name™')
-        self.assertEquals(self.tc.token.username, u'üsernåme')
-        self.assertEquals(self.tc.token.user_nsid, u'user—nsid')
+        self.assertEqual(self.tc.token.token, u'nümbér')
+        self.assertEqual(self.tc.token.token_secret, u'səcret-tøken')
+        self.assertEqual(self.tc.token.access_level, u'read')
+        self.assertEqual(self.tc.token.fullname, u'My Full Name™')
+        self.assertEqual(self.tc.token.username, u'üsernåme')
+        self.assertEqual(self.tc.token.user_nsid, u'user—nsid')
 
         del self.tc.token
         self.assertIsNone(self.tc.token)


### PR DESCRIPTION
`assertEquals` is deprecated and causes these warnings in the build logs:
```
=============================== warnings summary ===============================
tests/test_tokencache.py::SimpleTokenCacheTest::test_get_set_del
  /home/travis/build/sybrenstuvel/flickrapi/tests/test_tokencache.py:14: DeprecationWarning: Please use assertEqual instead.
    self.assertEquals(self.tc.token, 'nümbér')
tests/test_tokencache.py::TokenCacheTest::test_get_set_del
  /home/travis/build/sybrenstuvel/flickrapi/tests/test_tokencache.py:44: DeprecationWarning: Please use assertEqual instead.
    self.assertEquals(self.tc.token, u'nümbér')
tests/test_tokencache.py::TokenCacheTest::test_get_set_del
  /home/travis/build/sybrenstuvel/flickrapi/tests/test_tokencache.py:46: DeprecationWarning: Please use assertEqual instead.
    self.assertEquals(on_disk.decode('utf8'), u'nümbér')
tests/test_tokencache.py::TokenCacheTest::test_get_set_del
  /home/travis/build/sybrenstuvel/flickrapi/tests/test_tokencache.py:50: DeprecationWarning: Please use assertEqual instead.
    self.assertEquals(self.tc.token, u'nümbér')
tests/test_tokencache.py::TokenCacheTest::test_username
  /home/travis/build/sybrenstuvel/flickrapi/tests/test_tokencache.py:69: DeprecationWarning: Please use assertNotEqual instead.
    self.assertNotEquals(tc_path, user_path)
tests/test_tokencache.py::OAuthTokenCache::test_get_set_del
  /home/travis/build/sybrenstuvel/flickrapi/tests/test_tokencache.py:99: DeprecationWarning: Please use assertEqual instead.
    self.assertEquals(self.tc.token.token, u'nümbér')
tests/test_tokencache.py::OAuthTokenCache::test_get_set_del
  /home/travis/build/sybrenstuvel/flickrapi/tests/test_tokencache.py:103: DeprecationWarning: Please use assertEqual instead.
    self.assertEquals(self.tc.token.token, u'nümbér')
tests/test_tokencache.py::OAuthTokenCache::test_get_set_del
  /home/travis/build/sybrenstuvel/flickrapi/tests/test_tokencache.py:104: DeprecationWarning: Please use assertEqual instead.
    self.assertEquals(self.tc.token.token_secret, u'səcret-tøken')
tests/test_tokencache.py::OAuthTokenCache::test_get_set_del
  /home/travis/build/sybrenstuvel/flickrapi/tests/test_tokencache.py:105: DeprecationWarning: Please use assertEqual instead.
    self.assertEquals(self.tc.token.access_level, u'read')
tests/test_tokencache.py::OAuthTokenCache::test_get_set_del
  /home/travis/build/sybrenstuvel/flickrapi/tests/test_tokencache.py:106: DeprecationWarning: Please use assertEqual instead.
    self.assertEquals(self.tc.token.fullname, u'My Full Name™')
tests/test_tokencache.py::OAuthTokenCache::test_get_set_del
  /home/travis/build/sybrenstuvel/flickrapi/tests/test_tokencache.py:107: DeprecationWarning: Please use assertEqual instead.
    self.assertEquals(self.tc.token.username, u'üsernåme')
tests/test_tokencache.py::OAuthTokenCache::test_get_set_del
  /home/travis/build/sybrenstuvel/flickrapi/tests/test_tokencache.py:108: DeprecationWarning: Please use assertEqual instead.
    self.assertEquals(self.tc.token.user_nsid, u'user—nsid')
```
https://travis-ci.org/sybrenstuvel/flickrapi/jobs/490922491#L716

This PR updates to use `assertEqual`, and updates some other asserts to give more informative messages if they fail.