### PR TITLE
Prevent Error 5: Filetype was not recognised specifying the file exte…

### DIFF
--- a/flickrapi/auth.py
+++ b/flickrapi/auth.py
@@ -285,7 +285,8 @@ class OAuthFlickrInterface(object):
 
         if not fileobj:
             fileobj = open(filename, 'rb')
-        params['photo'] = ('dummy name', fileobj)
+        unused_filename, file_extension = os.path.splitext(filename)
+        params['photo'] = ('dummy_name' + file_extension, fileobj)
         m = MultipartEncoder(fields=params)
         auth = {'Authorization': headers.get('Authorization'),
                 'Content-Type': m.content_type}


### PR DESCRIPTION
Prevent "Error 5: Filetype was not recognised" when uploading uncommon file types.
Tested with .mts and .m2ts.

While the current flickrapi is failing with the above error, the html official uploader is working as expected, when uploading .mts and .m2ts files.
I analyzed the HTTP log in the browser and noticed that the contet-type section of the actual file data was something like:
```
-----------------------------27598564016011352821359952635
Content-Disposition: form-data; name="photo"; filename="my_file.MTS"
Content-Type: video/vnd.dlna.mpeg-tts

```
Putting the extension in the filename (instead of "dummy name") did the trick. At this time the content-type does not seem required: the filename is probably triggering an auto resolution of the content-type by the Flickr servers

