### PR TITLE
Python 3.9 compatibility: remove call to missing ElementTree function

### DIFF
--- a/flickrapi/core.py
+++ b/flickrapi/core.py
@@ -686,7 +686,7 @@ class FlickrAPI(object):
                       (method.__name__, page, total, params))
             rsp = method(page=page, **params)
 
-            photoset = rsp.getchildren()[0]
+            photoset = rsp[0]
             total = int(photoset.get('pages'))
 
             photos = rsp.findall(searchstring)


### PR DESCRIPTION
getchildren() was deprecated in 3.2 and removed in 3.9.

> Methods getchildren() and getiterator() of classes ElementTree and Element in the ElementTree module have been removed. They were deprecated in Python 3.2. Use iter(x) or list(x) instead of x.getchildren() and x.iter() or list(x.iter()) instead of x.getiterator(). (Contributed by Serhiy Storchaka in bpo-36543.)

from https://docs.python.org/3/whatsnew/3.9.html