### PR TITLE
introduce FlickrDuplicate exception

### DIFF
--- a/flickrapi/core.py
+++ b/flickrapi/core.py
@@ -245,7 +245,13 @@ class FlickrAPI(object):
             return rsp
 
         err = rsp.err[0]
-        raise FlickrError('Error: %(code)s: %(msg)s' % err, code=err['code'])
+        code = err['code']
+        if int(code) == 9:
+            dup_id = rsp.duplicate_photo_id[0].text
+            raise FlickrDuplicate('Duplicate photo',
+                                  duplicate_photo_id=dup_id)
+
+        raise FlickrError('Error: %(code)s: %(msg)s' % err, code=code)
 
     @rest_parser('parsed-json', 'json')
     def parse_json(self, json_string):
@@ -293,6 +299,11 @@ class FlickrAPI(object):
 
         err = rsp.find('err')
         code = err.attrib.get('code', None)
+        if int(code) == 9:
+            dup_id = rsp.find('duplicate_photo_id')
+            raise FlickrDuplicate('Duplicate photo',
+                                  duplicate_photo_id=dup_id.text)
+
         raise FlickrError('Error: %(code)s: %(msg)s' % err.attrib, code=code)
 
     def __getattr__(self, method_name):

--- a/flickrapi/exceptions.py
+++ b/flickrapi/exceptions.py
@@ -25,6 +25,22 @@ class FlickrError(Exception):
             self.code = int(code)
 
 
+class FlickrDuplicate(Exception):
+    """Raised when Flickr detects duplicate photo being uploaded.
+
+    The duplicate detection only happens if the upload request contains
+    the 'dedup_check' parameter set to either 1 or 2.
+
+    The exception contains ID of the duplicate photo as returned
+    from the API call.
+
+    """
+    def __init__(self, message, duplicate_photo_id):
+        super().__init__(self, message)
+
+        self.duplicate_photo_id = duplicate_photo_id
+
+
 class CancelUpload(Exception):
     """Raise this exception in an upload/replace callback function to
     abort the upload.


### PR DESCRIPTION
The Flickr [upload API](https://www.flickr.com/services/api/upload.api.html) allows to specify `dedup_check` parameter with value either 1 or 2. This is actually what the official Flickr Uploadr app is using by default. When a duplicate photo is detected, the response returns the ID of the original photo. The photo being duplicate does not seem like a hard error to me, that's why this change proposes to add `FlickrDuplicate` exception that stores the photo ID.

This way it is possible to construct a piece of code that always returns photo ID:
```python
    with open(file_path, 'rb') as fp:                                           
        try:                                                                    
            rsp = flickr_handle.upload(file_path, fileobj=fp,                   
                                       **params)                                
            logger.debug(ElementTree.tostring(rsp, 'utf-8'))                    
            photo_id = rsp.find('photoid')                                      
            if photo_id is not None:                                            
                res = photo_id.text                                             
        except flickrapi.exceptions.FlickrDuplicate as e:                       
            logger.info("Duplicate photo '{}' with ID {}".                      
                        format(file_path, e.duplicate_photo_id))                
            res = e.duplicate_photo_id
```
which is particularly useful when uploading set of photos and adding them to an album.

I was not able to get `parse_json()` to work with `flickr_handle.upload()` - even though the flickr handle was constructed with `format='parsed-json'`, the `parse_json()` still received XML as input. So I left it unchanged.