### PR TITLE
Add missing tests dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 /.idea/
 /.tox
 __pycache__
+.pytest_cache

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     'Programming Language :: Python :: Implementation :: CPython',
     'Programming Language :: Python :: Implementation :: PyPy',
     'Topic :: Multimedia :: Graphics',
-    'Topic :: Software Development :: Libraries :: Python Modules'
+    'Topic :: Software Development :: Libraries :: Python Modules',
 ]
 
 [tool.poetry.extras]
@@ -38,6 +38,7 @@ pytest = "~5.0"
 pytest-cov = "~2.7"
 responses = ">0.5.1"
 tox = "^3.14"
+setuptools = "49.6.0"
 
 
 [build-system]


### PR DESCRIPTION
test_flickrapi.py depends on pkg_resources, so adding setuptools as a dev dependency

(and ignores the pytest cache directory while at it)